### PR TITLE
'New Window' has become 'New File' in Python > 3.2

### DIFF
--- a/en-GB/lessons/ASCII Art/ASCII Art - notes.md
+++ b/en-GB/lessons/ASCII Art/ASCII Art - notes.md
@@ -8,7 +8,7 @@ embeds: "*.png"
 This project teaches children how to run a simple Python program, and how to print text to the screen. Children will write programs to print ASCII art to the screen.
 
 #Resources
-For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed.
+For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed. Note that on newer versions of Python the `File → New Window` menu option has been replaced by `File → New File`.
 
 Children can also make use of the materials which accompany these challenges. Files included in the 'Project Resources' folder (found under the 'Download Project Materials' link):
 

--- a/en-GB/lessons/ASCII Art/ASCII Art - notes.md
+++ b/en-GB/lessons/ASCII Art/ASCII Art - notes.md
@@ -8,7 +8,7 @@ embeds: "*.png"
 This project teaches children how to run a simple Python program, and how to print text to the screen. Children will write programs to print ASCII art to the screen.
 
 #Resources
-For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed. Note that on newer versions of Python the `File → New Window` menu option has been replaced by `File → New File`.
+For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed.
 
 Children can also make use of the materials which accompany these challenges. Files included in the 'Project Resources' folder (found under the 'Download Project Materials' link):
 
@@ -31,6 +31,7 @@ Make sure that each child has read and write access to their own copy of these r
 + Code a scarf - expressions using numbers and text strings.
 
 #Frequently Asked Questions
++ In versions of Python newer than 3.2 the `File → New Window` menu option has been replaced by `File → New File`.
 + Children should make sure they type `.py` at the end of their filename when saving. This allows IDLE to use syntax highlighting, which improves code readability.
 + Children will not yet have learnt about the backslash escape character `\`. This means that they will get an error message if they try and use a backslash immediately before the end speechmark in their `print()` statement. This problem can be solved by putting a space between a backslash and any speech marks.
 + Children should not use the speech mark character `"` anywhere within a print statement, as the editor will incorrectly assume that this marks the end of the printed text.


### PR DESCRIPTION
I have just used this worksheet for the first time and we found that the option on the 'File' menu is 'New File' not 'New Window'. It looks like a change in Python 3.3. I thought about making a change to the worksheet itself but the notes recommend 3.2 so I thought it would be more appropriate to add a warning for the volunteer.