### PR TITLE
fixed potential security issue: eval is unsafe, use ast.literal_eval instead

### DIFF
--- a/en-GB/lessons/Pokedex/Project Resources/pokeapi.py
+++ b/en-GB/lessons/Pokedex/Project Resources/pokeapi.py
@@ -1,18 +1,19 @@
 import io
 import urllib.request
 from urllib.request import urlopen
+import ast
 from PIL import Image, ImageTk
 
 #function to get the data for a pokemon
 def getPokemonData(num):
     data = urllib.request.urlopen("http://pokeapi.co/api/v1/pokemon/"+str(num)).read()
-    pokemonDict = eval(data)
+    pokemonDict = ast.literal_eval(data.decode(encoding='UTF-8'))
     return pokemonDict
 
 #function to get the image for a pokemon
 def getPokemonImage(num):
     data = urllib.request.urlopen("http://pokeapi.co/api/v1/sprite/"+str(num)).read()
-    spriteDict = eval(data)
+    spriteDict = ast.literal_eval(data.decode(encoding='UTF-8'))
     imgURL = "http://pokeapi.co" + spriteDict["image"]
     image_bytes = urlopen(imgURL).read()
     data_stream = io.BytesIO(image_bytes)


### PR DESCRIPTION
Usage of eval has potential security consequences.  Patch uses the safer ast eval methods instead.  Tested on Python 3.4