### PR TITLE
Correction to a web service reference

### DIFF
--- a/en-GB/lessons/ISS/ISS.md
+++ b/en-GB/lessons/ISS/ISS.md
@@ -154,7 +154,7 @@ Let’s use another web service to find out where the International Space Statio
 
 ## Activity Checklist { .check}
 
-+ First open the url for the web service in a new tab in your web browser: <a href="http://api.open-notify.org/astros.json" target="_blank">http://api.open-notify.org/astros.json</a>
++ First open the url for the web service in a new tab in your web browser: <a href="http://api.open-notify.org/iss-now.json" target="_blank">http://api.open-notify.org/iss-now.json</a>
   
   You should see something like this:
   


### PR DESCRIPTION
Correction to the web service referenced for 'where is the ISS now' to use iss-now.json (instead of astro.json)